### PR TITLE
FIX: Multiple fixes for ganglion accel and cyton aux data over wifi

### DIFF
--- a/app/env.json
+++ b/app/env.json
@@ -1,4 +1,4 @@
 {
-  "name": "production",
+  "name": "development",
   "description": "Add here any environment specific stuff you like."
 }

--- a/app/package.json
+++ b/app/package.json
@@ -2,7 +2,7 @@
   "name": "openbci-electron-hub",
   "productName": "OpenBCIHub",
   "description": "OpenBCIHub",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": "AJ Keller <hello@pushtheworld.us>",
   "copyright": "© 2017, OpenBCI inc.",
   "homepage": "http://openbci.com",
@@ -16,7 +16,7 @@
     "node-ssdp": "^3.2.1",
     "openbci-cyton": "^1.0.5",
     "openbci-ganglion": "^0.4.3",
-    "openbci-utilities": "^0.2.3",
-    "openbci-wifi": "^0.2.0"
+    "openbci-utilities": "^0.2.4",
+    "openbci-wifi": "^0.2.1"
   }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,15 @@
+# v1.3.0
+
+### Bug Fixes
+
+* Issue with ganglion channel data not sent
+* Issue where cyton aux data not sent
+
+### Breaking Changes
+
+* Ganglion data over wifi has only 4 channels (as it's supposed to)
+* Ganglion accel data over wifi sent with packet instead of in separate packet to prevent misalignment.
+
 # v1.2.0
 
 Fixing bugs with AppVeyor build service.


### PR DESCRIPTION
# v1.3.0

### Bug Fixes

* Issue with ganglion channel data not sent
* Issue where cyton aux data not sent

### Breaking Changes

* Ganglion data over wifi has only 4 channels (as it's supposed to)
* Ganglion accel data over wifi sent with packet instead of in separate packet to prevent misalignment.