### PR TITLE
FIX: daisy not getting stop bytes

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -14,7 +14,7 @@
     "lodash": "^4.16.6",
     "menubar": "^5.1.0",
     "node-ssdp": "^3.2.1",
-    "openbci-cyton": "^1.0.5",
+    "openbci-cyton": "^1.0.6",
     "openbci-ganglion": "^1.0.0",
     "openbci-utilities": "^0.2.7",
     "openbci-wifi": "^0.3.0"

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 * Stopped wifi scan in wifi cleanup
 * Cleaned up event listeners for cyton/ganglion/wifi disconnect
 * Fixed bug with daisy not getting accel data or stop byte by bumping wifi version to 0.3.0
+* Daisy with cyton now get's stop bytes with bump to 1.0.6
 
 # v1.3.2
 


### PR DESCRIPTION
# v1.3.3

### Bug Fixes

* Update ganglion node driver to 1.0.0
* Stopped wifi scan in wifi cleanup
* Cleaned up event listeners for cyton/ganglion/wifi disconnect
* Fixed bug with daisy not getting accel data or stop byte by bumping wifi version to 0.3.0
* Daisy with cyton now get's stop bytes with bump to 1.0.6